### PR TITLE
Fix potential reflective Cross-site Scripting vulnerability

### DIFF
--- a/Overflow/Overflow/App_Code/UmbContactController.cs
+++ b/Overflow/Overflow/App_Code/UmbContactController.cs
@@ -19,7 +19,7 @@ namespace Overflow.Controllers
             // The model defines validations for empty or invalid email addresses
             // See the UmbContactMail class below 
             if (ModelState.IsValid == false)
-                return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ModelState.First().Value.Errors.First().ErrorMessage);
+                return Request.CreateErrorResponse(HttpStatusCode.BadRequest, HttpContext.Current.Server.HtmlEncode(ModelState.First().Value.Errors.First().ErrorMessage));
 
             // In order to allow editors to configure the email address where contact 
             // mails will be sent, we require that to be set in a property with the


### PR DESCRIPTION
A security audit of a u7 site based on overflow starter kit found a cross site script injection vulnerability in the UmbContactController. When you enter an invalid string value for settingsNodeId the ModelState changes to invalid and this code (in app_code) echos the error including the invalid value back into the page without encoding. 
Request.CreateErrorResponse(HttpStatusCode.BadRequest, ModelState.First().Value.Errors.First().ErrorMessage);
I am pretty sure that Request.CreateErrorResponse was patched via windows update to encode internally as I cannot reproduce the fault on my local development machine but I can see an un-encoded response in the penetration testing results document I was sent.
https://dl.dropboxusercontent.com/u/2923715/WOW77XSSVul.docx
